### PR TITLE
Don't return remote objects

### DIFF
--- a/src/helpers/__tests__/getInitialStateRenderer.js
+++ b/src/helpers/__tests__/getInitialStateRenderer.js
@@ -5,8 +5,9 @@ jest.unmock('../getInitialStateRenderer');
 
 describe('getInitialStateRenderer', () => {
   it('should return the initial state', () => {
-    remote.getGlobal.mockImplementation(() => 456);
+    const state = { foo: 456 };
+    remote.getGlobal.mockImplementation(() => () => JSON.stringify(state));
 
-    expect(getInitialStateRenderer()).toBe(456);
+    expect(getInitialStateRenderer()).toEqual(state);
   });
 });

--- a/src/helpers/__tests__/replayActionMain.js
+++ b/src/helpers/__tests__/replayActionMain.js
@@ -25,25 +25,24 @@ describe('replayActionMain', () => {
     expect(store.dispatch).toHaveBeenCalledWith(payload);
   });
 
-  it('should subscribe to the store and update the global state', () => {
+  it('should return the current state from the global', () => {
     const initialState = { initial: 'state' };
     const newState = { new: 'state' };
     const store = {
       dispatch: jest.fn(),
-      getState: jest.fn(() => initialState),
+      getState: jest.fn(),
       subscribe: jest.fn(),
     };
 
+    store.getState.mockReturnValueOnce(initialState);
+    store.getState.mockReturnValueOnce(newState);
+
     replayActionMain(store);
 
-    expect(global.reduxState).toEqual(initialState);
-    expect(store.subscribe).toHaveBeenCalledTimes(1);
-    expect(store.subscribe.mock.calls[0][0]).toBeInstanceOf((Function));
+    expect(global.getReduxState()).toEqual(JSON.stringify(initialState));
+    expect(store.getState).toHaveBeenCalledTimes(1);
 
-    const subscribeCb = store.subscribe.mock.calls[0][0];
-    store.getState = jest.fn(() => newState);
-    subscribeCb();
-
-    expect(global.reduxState).toEqual(newState);
+    expect(global.getReduxState()).toEqual(JSON.stringify(newState));
+    expect(store.getState).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/helpers/getInitialStateRenderer.js
+++ b/src/helpers/getInitialStateRenderer.js
@@ -1,5 +1,9 @@
 import { remote } from 'electron';
 
 export default function getInitialStateRenderer() {
-  return remote.getGlobal('reduxState');
+  const getReduxState = remote.getGlobal('getReduxState');
+  if (!getReduxState) {
+    throw new Error('Could not find reduxState global in main process, did you forget to call replayActionMain?');
+  }
+  return JSON.parse(getReduxState());
 }

--- a/src/helpers/replayActionMain.js
+++ b/src/helpers/replayActionMain.js
@@ -1,11 +1,14 @@
 import { ipcMain } from 'electron';
 
 export default function replayActionMain(store) {
-  // we have to do this to ease remote-loading of the initial state :(
-  global.reduxState = store.getState();
-  store.subscribe(() => {
-    global.reduxState = store.getState();
-  });
+  /**
+   * Give renderers a way to sync the current state of the store, but be sure
+   * we don't expose any remote objects. In other words, we need our state to
+   * be serializable.
+   *
+   * Refer to https://github.com/electron/electron/blob/master/docs/api/remote.md#remote-objects
+   */
+  global.getReduxState = () => JSON.stringify(store.getState());
 
   ipcMain.on('redux-action', (event, payload) => {
     store.dispatch(payload);


### PR DESCRIPTION
The current implementation for `getInitialStateRenderer` returns a remote object directly:

``` js
return remote.getGlobal('reduxState');
```

From the [Electron docs](https://github.com/electron/electron/blob/master/docs/api/remote.md#remote-objects):
>Each object (including functions) returned by the `remote` module represents an object in the main process (we call it a remote object or remote function). When you invoke methods of a remote object, call a remote function, or create a new object with the remote constructor (function), you are actually sending synchronous inter-process messages.

What this means is that the state given to the renderer processes will be a shim to the object in the main process, and any attempt to access that state will call `ipcRenderer.sendSync` under the surface! This makes things very slow.

Fortunately there's an easy workaround, it's the same one applied over here: https://github.com/samiskin/redux-electron-store/pull/33. We just make this a remote _method_, and ensure that the method only returns primitive types (by serializing the state). Then, we can guarantee that Electron's IPC will copy them:

>Note: Arrays and Buffers are copied over IPC when accessed via the remote module. Modifying them in the renderer process does not modify them in the main process and vice versa.