### PR TITLE
Forward actions to all webContents

### DIFF
--- a/src/__mocks__/electron.js
+++ b/src/__mocks__/electron.js
@@ -1,7 +1,7 @@
 export default jest.fn();
 
-export const BrowserWindow = {
-  getAllWindows: jest.fn(() => []),
+export const webContents = {
+  getAllWebContents: jest.fn(() => []),
 };
 
 export const ipcMain = {

--- a/src/middleware/__tests__/forwardToRenderer.js
+++ b/src/middleware/__tests__/forwardToRenderer.js
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron';
+import { webContents } from 'electron';
 import forwardToRenderer from '../forwardToRenderer';
 
 jest.unmock('../forwardToRenderer');
@@ -23,13 +23,7 @@ describe('forwardToRenderer', () => {
       },
     };
     const send = jest.fn();
-    BrowserWindow.getAllWindows.mockImplementation(() => [
-      {
-        webContents: {
-          send,
-        },
-      },
-    ]);
+    webContents.getAllWebContents.mockImplementation(() => [{ send }]);
 
     forwardToRenderer()(next)(action);
 
@@ -52,13 +46,7 @@ describe('forwardToRenderer', () => {
       },
     };
     const send = jest.fn();
-    BrowserWindow.getAllWindows.mockImplementation(() => [
-      {
-        webContents: {
-          send,
-        },
-      },
-    ]);
+    webContents.getAllWebContents.mockImplementation(() => [{ send }]);
 
     forwardToRenderer()(next)(action);
 

--- a/src/middleware/forwardToRenderer.js
+++ b/src/middleware/forwardToRenderer.js
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron';
+import { webContents } from 'electron';
 import validateAction from '../helpers/validateAction';
 
 const forwardToRenderer = () => next => (action) => {
@@ -14,9 +14,10 @@ const forwardToRenderer = () => next => (action) => {
     },
   };
 
-  const openWindows = BrowserWindow.getAllWindows();
-  openWindows.forEach(({ webContents }) => {
-    webContents.send('redux-action', rendererAction);
+  const allWebContents = webContents.getAllWebContents();
+
+  allWebContents.forEach((contents) => {
+    contents.send('redux-action', rendererAction);
   });
 
   return next(action);


### PR DESCRIPTION
This PR causes actions in the main process to be forwarded to all renderer processes using [`webContents.getAllWebContents`](https://github.com/electron/electron/blob/master/docs/api/web-contents.md#webcontentsgetallwebcontents). From the docs:

>This will contain web contents for all windows, webviews, opened devtools, and devtools extension background pages.

Just sending to `BrowserWindow.webContents` will omit any embedded `webview` guest pages, even though those are valid `renderer` processes.