### PR TITLE
Target IE 9 instead of Node 4 to be compatible with Create React App

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
     [
       "env", {
         "targets": {
-          "node": 4
+          "ie": 9
         }
       }
     ],


### PR DESCRIPTION
Hi,

This PR changes babel's target from Node 4 to IE 9 to be able to be bundled with Create React App (CRA) generated apps since it's minification process [only supports ES5 syntax on its imported modules](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify).

Here's the [diff](https://github.com/hardchor/electron-redux/files/1485866/diff.txt) that it means to use target IE9, it's only 7 changes away.

What're your thoughts on this?

Thanks,
Darío