### PR TITLE
Make electron requires compatible with webpack bundling

### DIFF
--- a/packages/electron-redux/src/helpers/getInitialStateRenderer.js
+++ b/packages/electron-redux/src/helpers/getInitialStateRenderer.js
@@ -1,9 +1,11 @@
-import { remote } from 'electron';
+const { remote } = typeof window != 'undefined' ? window.require('electron') : require('electron');
 
 export default function getInitialStateRenderer() {
   const getReduxState = remote.getGlobal('getReduxState');
   if (!getReduxState) {
-    throw new Error('Could not find reduxState global in main process, did you forget to call replayActionMain?');
+    throw new Error(
+      'Could not find reduxState global in main process, did you forget to call replayActionMain?',
+    );
   }
   return JSON.parse(getReduxState());
 }

--- a/packages/electron-redux/src/helpers/replayActionMain.js
+++ b/packages/electron-redux/src/helpers/replayActionMain.js
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron';
+const { ipcMain } = typeof window != 'undefined' ? window.require('electron') : require('electron');
 
 export default function replayActionMain(store) {
   /**

--- a/packages/electron-redux/src/helpers/replayActionRenderer.js
+++ b/packages/electron-redux/src/helpers/replayActionRenderer.js
@@ -1,4 +1,5 @@
-import { ipcRenderer } from 'electron';
+const { ipcRenderer } =
+  typeof window != 'undefined' ? window.require('electron') : require('electron');
 
 export default function replayActionRenderer(store) {
   ipcRenderer.on('redux-action', (event, payload) => {

--- a/packages/electron-redux/src/middleware/forwardToMain.js
+++ b/packages/electron-redux/src/middleware/forwardToMain.js
@@ -1,4 +1,5 @@
-import { ipcRenderer } from 'electron';
+const { ipcRenderer } =
+  typeof window != 'undefined' ? window.require('electron') : require('electron');
 import validateAction from '../helpers/validateAction';
 
 // eslint-disable-next-line consistent-return, no-unused-vars

--- a/packages/electron-redux/src/middleware/forwardToRenderer.js
+++ b/packages/electron-redux/src/middleware/forwardToRenderer.js
@@ -1,7 +1,8 @@
-import { webContents } from 'electron';
+const { webContents } =
+  typeof window != 'undefined' ? window.require('electron') : require('electron');
 import validateAction from '../helpers/validateAction';
 
-const forwardToRenderer = () => next => (action) => {
+const forwardToRenderer = () => next => action => {
   if (!validateAction(action)) return next(action);
   if (action.meta && action.meta.scope === 'local') return next(action);
 
@@ -16,7 +17,7 @@ const forwardToRenderer = () => next => (action) => {
 
   const allWebContents = webContents.getAllWebContents();
 
-  allWebContents.forEach((contents) => {
+  allWebContents.forEach(contents => {
     contents.send('redux-action', rendererAction);
   });
 


### PR DESCRIPTION
Suggested fix for https://github.com/hardchor/electron-redux/issues/129

When using electron with a renderer bundled by webpack, electron requires need to happen on the window object. 