### PR TITLE
Added return for redux-action-chainability

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.5.1",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
     "test": "lerna run test",
-    "postinstall": "lerna run build"
+    "postinstall": "yarn run build"
   },
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "postinstall": "lerna run build"
   },
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
-    "test": "lerna run test",
-    "postinstall": "lerna bootstrap && lerna run build"
+    "test": "lerna run test"
   },
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
     "test": "lerna run test",
-    "postinstall": "yarn run bootstrap && yarn run build"
+    "postinstall": "lerna bootstrap && lerna run build"
   },
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
-    "test": "lerna run test",
-    "prepare": "lerna bootstrap && lerna run build"
+    "test": "lerna run test"
   },
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "prepare": "lerna bootstrap && lerna run build"
   },
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
     "test": "lerna run test",
-    "postinstall": "yarn run build"
+    "postinstall": "yarn run bootstrap && yarn run build"
   },
   "workspaces": [
     "packages/*"

--- a/packages/electron-redux-e2e/package.json
+++ b/packages/electron-redux-e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-redux-e2e",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "The end-to-end tests for electron-redux",
   "main": "dist/main/main.js",
   "repository": "https://github.com/hardchor/electron-redux/tree/master/packages/electron-redux-e2e",
@@ -9,7 +9,7 @@
   "private": true,
   "dependencies": {
     "electron": "^8.2.4",
-    "electron-redux": "^1.5.2",
+    "electron-redux": "^1.5.3",
     "electron-webpack": "^2.8.2",
     "redux": "^4.0.1",
     "source-map-support": "^0.5.19",

--- a/packages/electron-redux/package.json
+++ b/packages/electron-redux/package.json
@@ -12,7 +12,7 @@
     "build": "rm -rf dist && babel src --out-dir dist",
     "prepare": "yarn build",
     "prepush": "yarn test && yarn build",
-    "postinstall": "yarn run lint && yarn run build"
+    "postinstall": "yarn run build"
   },
   "keywords": [
     "electron",

--- a/packages/electron-redux/package.json
+++ b/packages/electron-redux/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "test": "rm -rf coverage && jest --coverage",
-    "lint": "eslint 'src/**/*'",
+    "lint": "eslint --fix 'src/**/*'",
     "build": "rm -rf dist && babel src --out-dir dist",
     "prepare": "yarn build",
     "prepush": "yarn test && yarn build",

--- a/packages/electron-redux/package.json
+++ b/packages/electron-redux/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint 'src/**/*'",
     "build": "rm -rf dist && babel src --out-dir dist",
     "prepare": "yarn build",
-    "prepush": "yarn test && yarn build"
+    "prepush": "yarn test && yarn build",
+    "postinstall": "yarn run lint && yarn run build"
   },
   "keywords": [
     "electron",

--- a/packages/electron-redux/package.json
+++ b/packages/electron-redux/package.json
@@ -8,11 +8,10 @@
   ],
   "scripts": {
     "test": "rm -rf coverage && jest --coverage",
-    "lint": "eslint --fix 'src/**/*'",
+    "lint": "eslint 'src/**/*'",
     "build": "rm -rf dist && babel src --out-dir dist",
     "prepare": "yarn build",
-    "prepush": "yarn test && yarn build",
-    "postinstall": "yarn run build"
+    "prepush": "yarn test && yarn build"
   },
   "keywords": [
     "electron",

--- a/packages/electron-redux/package.json
+++ b/packages/electron-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-redux",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Use redux in the main and browser process in electron",
   "main": "dist/index.js",
   "files": [

--- a/packages/electron-redux/src/middleware/__tests__/forwardToMain.js
+++ b/packages/electron-redux/src/middleware/__tests__/forwardToMain.js
@@ -70,7 +70,7 @@ describe('forwardToMain', () => {
     expect(ipcRenderer.send).toHaveBeenCalledTimes(1);
     expect(ipcRenderer.send).toHaveBeenCalledWith('redux-action', action);
 
-    expect(next).toHaveBeenCalledTimes(0);
+    expect(next).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -89,7 +89,7 @@ describe('forwardToMainWithParams', () => {
     expect(ipcRenderer.send).toHaveBeenCalledTimes(1);
     expect(ipcRenderer.send).toHaveBeenCalledWith('redux-action', action);
 
-    expect(next).toHaveBeenCalledTimes(0);
+    expect(next).toHaveBeenCalledTimes(1);
   });
 
   it('should forward an action through if it starts with redux-form', () => {
@@ -101,7 +101,7 @@ describe('forwardToMainWithParams', () => {
     expect(ipcRenderer.send).toHaveBeenCalledTimes(1);
     expect(ipcRenderer.send).toHaveBeenCalledWith('redux-action', action);
 
-    expect(next).toHaveBeenCalledTimes(0);
+    expect(next).toHaveBeenCalledTimes(1);
   });
 
   it('should pass an action through if it is blacklisted', () => {

--- a/packages/electron-redux/src/middleware/forwardToMain.js
+++ b/packages/electron-redux/src/middleware/forwardToMain.js
@@ -13,6 +13,7 @@ export const forwardToMainWithParams = (params = {}) => store => next => (action
 
   // stop action in-flight
   ipcRenderer.send('redux-action', action);
+  return next(action);
 };
 
 const forwardToMain = forwardToMainWithParams({


### PR DESCRIPTION
I had a problem when I tried to chain a redux action to a first action to save userdata (image).
This return-statement enables this ability.

![image](https://user-images.githubusercontent.com/33860193/81802085-bb73c600-9515-11ea-9cfe-16339d5f1304.png)
