### PR TITLE
feat: remove flux-standard-action

### DIFF
--- a/packages/electron-redux/package.json
+++ b/packages/electron-redux/package.json
@@ -29,7 +29,6 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^4.1.1",
-    "flux-standard-action": "^2.0.0",
     "redux": "^4.0.1"
   },
   "peerDependencies": {

--- a/packages/electron-redux/src/helpers/__tests__/validateAction.js
+++ b/packages/electron-redux/src/helpers/__tests__/validateAction.js
@@ -1,7 +1,7 @@
 import validateAction from '../validateAction';
 
 jest.unmock('../validateAction');
-jest.unmock('flux-standard-action');
+jest.unmock('../fluxStandardAction');
 
 describe('validateAction', () => {
   it('should accept FSA-compliant actions', () => {
@@ -19,5 +19,6 @@ describe('validateAction', () => {
     expect(validateAction({})).toBeFalsy();
     expect(validateAction({ meta: {} })).toBeFalsy();
     expect(validateAction(() => {})).toBeFalsy();
+    expect(validateAction([])).toBeFalsy();
   });
 });

--- a/packages/electron-redux/src/helpers/fluxStandardAction.js
+++ b/packages/electron-redux/src/helpers/fluxStandardAction.js
@@ -1,0 +1,16 @@
+function isValidKey(key) {
+  return ['type', 'payload', 'error', 'meta'].indexOf(key) > -1;
+}
+
+export function isFSA(action) {
+  return (
+    typeof action === 'object'
+    && !Array.isArray(action)
+    && typeof action.type === 'string'
+    && Object.keys(action).every(isValidKey)
+  );
+}
+
+export function isError(action) {
+  return isFSA(action) && action.error === true;
+}

--- a/packages/electron-redux/src/helpers/validateAction.js
+++ b/packages/electron-redux/src/helpers/validateAction.js
@@ -1,5 +1,5 @@
-import { isFSA } from 'flux-standard-action';
 import debug from 'debug';
+import { isFSA } from './fluxStandardAction';
 
 const log = debug('electron-redux:validateAction');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5513,13 +5513,6 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-flux-standard-action@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/flux-standard-action/-/flux-standard-action-2.1.1.tgz#b2e204145ea8e4294d6b0f178d8e8c416802948f"
-  integrity sha512-W86GzmXmIiTVq/dpYVd2HtTIUX9c35Iq3ao3xR6qcKtuXgbu+BDEj72op5VnEIe/kpuSbhl+I8kT1iS2hpcusw==
-  dependencies:
-    lodash "^4.17.15"
-
 follow-redirects@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.11.0.tgz#afa14f08ba12a52963140fe43212658897bc0ecb"


### PR DESCRIPTION
## Motivation

I've noticed my bundle is including `lodash` even though I haven't defined. After doing some tests & research I pin-pointed `lodash` to here, which includes it from `flux-standard-action`.

Seems that `flux-standard-action` is an abandoned project and it's fairly simple. By removing it, packages using this library will reduce bundle size by not having to depend on `lodash`.

## Why not fix `flux-standard-action` instead?

As I said, it's abandoned and there's a PR to fix it there since last year that hasn't get merged. I'm currently fixing it in my package by adding an `alias` in webpack for `flux-standard-action` & point it to a local file, but probably it'll be better to also fix it here. This library even has some tests to check that the actions are compliant 😄 👍 